### PR TITLE
feat(settings): 添加文章封面图显示设置

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -632,6 +632,15 @@ spec:
               value: true
             - label: 隐藏
               value: false
+        - $formkit: radio
+          name: showPostCover
+          label: 是否展示文章封面图
+          value: true
+          options:
+            - label: 显示
+              value: true
+            - label: 隐藏
+              value: false
 
     - group: sidebar
       label: 侧栏

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -24,12 +24,16 @@
                     <div class="article-sort" th:each="month : ${archive.months}">
                         <!-- 月份没有样式所以不显示 -->
                         <!-- <div class="article-sort-item" th:text="${month.month}"></div> -->
-                        <div class="article-sort-item" th:each="post : ${month.posts}">
-                            <a class="article-sort-item-img" th:href="@{${post.status.permalink}}"
-                               th:title="${post.spec.title}">
-                                <img th:alt="${post.spec.title}"
-                                     th:src="${#strings.isEmpty(post.spec.cover) ? postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, 's')}">
-                            </a>
+                        <div class="article-sort-item" th:each="post : ${month.posts}"
+                             th:classappend="!${theme.config.layout.showPostCover} ? 'article-sort-item--no-cover' : ''">
+                            <th:block th:if="${theme.config.layout.showPostCover}">
+                                <a class="article-sort-item-img" th:href="@{${post.status.permalink}}"
+                                   th:title="${post.spec.title}">
+                                    <img class="post_cover_img"
+                                         th:src="${#strings.isEmpty(post.spec.cover) ? postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, 's')}"
+                                         th:alt="${post.spec.title}">
+                                </a>
+                            </th:block>
                             <div class="article-sort-item-info">
                                 <div class="article-sort-item-time"><i class="far fa-calendar-alt"></i>
                                     <time class="post-meta-date-created"

--- a/templates/assets/css/main.css
+++ b/templates/assets/css/main.css
@@ -1,0 +1,93 @@
+.recent-post-item--no-cover .recent-post-info {
+  margin-top: 0 !important;
+  padding-top: 2rem !important;
+}
+.recent-post-item--no-cover {
+  min-height: 180px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.recent-posts-item--no-cover .content {
+  margin-left: 0 !important;
+  padding: 0.5rem 0 !important;
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+}
+.recent-posts-item--no-cover .thumbnail {
+  display: none !important;
+}
+
+/* 归档页无封面项样式 */
+.article-sort-item--no-cover .article-sort-item-img {
+  display: none !important;
+}
+
+.article-sort-item--no-cover .article-sort-item-info {
+  margin-left: 0 !important;
+  padding-left: 0.5rem !important;
+}
+
+/* 上一篇/下一篇导航无封面样式 */
+.prev-post a:not(:has(img)), .next-post a:not(:has(img)) {
+  padding-left: 10px !important;
+}
+
+.prev-post a:not(:has(img)) .pagination-info, .next-post a:not(:has(img)) .pagination-info {
+  margin-left: 0 !important;
+}
+
+/* 统一无封面样式 */
+/* 阅读建议无封面样式 */
+.relatedPosts a:not(:has(img)) .content {
+  background-color: var(--heo-card-bg);
+  border-radius: 0.5rem;
+  padding: 0.8rem !important;
+}
+
+/* 阅读建议六篇模式无封面样式 */
+.relatedPosts-list div:not(:has(img)) .content {
+  height: auto;
+  min-height: 80px;
+}
+
+/* 全局文章卡片统一样式 */
+[class*='--no-cover'] {
+  transition: all 0.3s;
+}
+
+/* 文章导航完善 */
+.pagination-post a:not(:has(img)) {
+  padding: 1rem;
+  align-items: center;
+  min-height: 80px;
+}
+
+/* 改进阅读建议在无封面时的样式 */
+.relatedPosts-list div:not(:has(img)) {
+  margin-bottom: 1rem;
+}
+
+/* 确保内容对齐 */
+.recent-posts-item--no-cover .content, .article-sort-item--no-cover .article-sort-item-info {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+/* 阅读建议项目无封面样式 */
+.related-post-item--no-cover .content {
+  padding: 1rem !important;
+  background-color: var(--heo-card-bg) !important;
+  border-radius: 0.5rem !important;
+  margin-bottom: 1rem !important;
+}
+
+.related-post-item--no-cover .content .title {
+  color: var(--heo-fontcolor) !important;
+  font-weight: 600 !important; 
+}
+
+.related-post-item--no-cover .content .date {
+  color: var(--heo-secondtextcolor) !important;
+} 

--- a/templates/error/404.html
+++ b/templates/error/404.html
@@ -33,13 +33,17 @@
                 <div class="aside-list-group"
                      th:with='topGroupPosts = ${postFinder.list(1,6)},
                 postRandomImg=${#strings.contains(theme.config.layout.postRandomImg,"?") ? theme.config.layout.postRandomImg+"&" : theme.config.layout.postRandomImg+"?"}'>
-                    <div th:each="post : ${topGroupPosts}" class="aside-list-item">
-                        <a class="thumbnail div_border"
-                           th:href="@{${post.status.permalink}}"
-                           th:title="${post.spec.title}"><img
-                                loading="lazy"
-                                th:src='${#strings.isEmpty(post.spec.cover) ? postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, "m")}'
-                                th:alt="${post.spec.title}"></a>
+                    <div th:each="post : ${topGroupPosts}" class="aside-list-item"
+                         th:classappend="!${theme.config.layout.showPostCover} ? 'recent-posts-item--no-cover' : ''">
+                        <th:block th:if="${theme.config.layout.showPostCover}">
+                            <a class="thumbnail div_border"
+                               th:href="@{${post.status.permalink}}"
+                               th:title="${post.spec.title}">
+                                <img class="post_cover_img"
+                                     th:src='${#strings.isEmpty(post.spec.cover) ? postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, "m")}'
+                                     th:alt="${post.spec.title}">
+                            </a>
+                        </th:block>
                         <div class="content">
                             <a class="title" th:href="@{${post.status.permalink}}"
                                th:title="${post.spec.title}"

--- a/templates/error/500.html
+++ b/templates/error/500.html
@@ -33,13 +33,17 @@
                 <div class="aside-list-group"
                      th:with='topGroupPosts = ${postFinder.list(1,6)},
                 postRandomImg=${#strings.contains(theme.config.layout.postRandomImg,"?") ? theme.config.layout.postRandomImg+"&" : theme.config.layout.postRandomImg+"?"}'>
-                    <div th:each="post : ${topGroupPosts}" class="aside-list-item">
-                        <a class="thumbnail div_border"
-                           th:href="@{${post.status.permalink}}"
-                           th:title="${post.spec.title}"><img
-                                loading="lazy"
-                                th:src='${#strings.isEmpty(post.spec.cover) ? postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, "m")}'
-                                th:alt="${post.spec.title}"></a>
+                    <div th:each="post : ${topGroupPosts}" class="aside-list-item"
+                         th:classappend="!${theme.config.layout.showPostCover} ? 'recent-posts-item--no-cover' : ''">
+                        <th:block th:if="${theme.config.layout.showPostCover}">
+                            <a class="thumbnail div_border"
+                               th:href="@{${post.status.permalink}}"
+                               th:title="${post.spec.title}">
+                                <img class="post_cover_img"
+                                     th:src='${#strings.isEmpty(post.spec.cover) ? postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, "m")}'
+                                     th:alt="${post.spec.title}">
+                            </a>
+                        </th:block>
                         <div class="content">
                             <a class="title" th:href="@{${post.status.permalink}}"
                                th:title="${post.spec.title}"

--- a/templates/macro/post-list.html
+++ b/templates/macro/post-list.html
@@ -6,10 +6,11 @@
         <div class="recent-post-item" th:classappend="${theme.config.layout.post.cols} + ' ' +
                         ${theme.config.layout.post.postLocation} + ' ' +
                         (${iStat.even} ? 'even' : 'odd') + ' ' +
-                        (${post.spec.pinned} ? 'pinned-post-item' : '')"
+                        (${post.spec.pinned} ? 'pinned-post-item' : '') + ' ' +
+                        (!${theme.config.layout.showPostCover} ? 'recent-post-item--no-cover' : '')"
              th:attr="onclick='pjax.loadUrl(\''+ @{${post.status.permalink}} +'\')'" th:each="post,iStat : ${postItems}">
 
-            <div class="post_cover left_radius">
+            <div class="post_cover left_radius" th:if="${theme.config.layout.showPostCover}">
                 <a th:attr="title=${post.spec.title}" th:href="@{${post.status.permalink}}">
                     <img class="post_bg"
                          th:with='img = ${#strings.isEmpty(post.spec.cover) ? postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, "m")}'

--- a/templates/modules/layouts/layout.html
+++ b/templates/modules/layouts/layout.html
@@ -78,11 +78,11 @@
 </th:block>
 
 <script th:inline="javascript">
-    
+    /*<![CDATA[*/
     function toRandomPost() {
         // 随机跳转首页的一篇文章
         // 后续改成跳转全站的文章，可以从 sitemap 中获取所有文章
-        let posts = [[${posts}]];
+        let posts = /*[[${posts}]]*/ {};
         
         let datum = posts.total < posts.size ? posts.total : posts.size;
         
@@ -95,7 +95,7 @@
         pjax.loadUrl(post.status.permalink)
         // window.open(post.status.permalink);
     }
-
+    /*]]>*/
 </script>
 
 <!-- 网站背景 -->
@@ -127,6 +127,16 @@
     <script th:src="${assets_link + '/js/main.js' + theme_version}"></script>
     <script charset="utf-8" data-pjax th:src="${assets_link + '/zhheo/blogex.js' + theme_version}"></script>
     <script th:src="${assets_link + '/js/tw_cn.js' + theme_version}"></script>
+    <script>
+        /*<![CDATA[*/
+        // 图片懒加载
+        const isLazyload = /*[[${theme.config.post.lazyload}]]*/ false; //配置是否开启图片懒加载
+        var loadingImg = '/assets/images/loading.gif';
+        if (!loadingImg.startsWith('http') && !loadingImg.startsWith('/')) {
+            loadingImg = '//' + loadingImg;
+        }
+        /*]]>*/
+    </script>
     <!-- https://instant.page/ 网站预加载， 放在 </body> 之前 -->
     <script src="https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/instant.page/5.1.0/instantpage.min.js"
             type="module"></script>
@@ -303,6 +313,7 @@
     }
 
 </script>
+
 </body>
 
 </html>

--- a/templates/modules/post-list.html
+++ b/templates/modules/post-list.html
@@ -7,12 +7,14 @@
          th:classappend="${theme.config.layout.post.cols} + ' ' +
          ${theme.config.layout.post.postLocation} + ' ' +
          (${iStat.even} ? 'even' : 'odd') + ' ' +
-         (${post.spec.pinned} ? 'pinned-post-item' : '')"
+         (${post.spec.pinned} ? 'pinned-post-item' : '') + ' ' +
+         (!${theme.config.layout.showPostCover} ? 'recent-post-item--no-cover' : '')"
          th:attr="onclick='pjax.loadUrl(\''+ @{${post.status.permalink}} +'\')'"
          th:each="post,iStat : ${postItems}">
-        <div class="post_cover left_radius">
+        <div class="post_cover left_radius" th:if="${theme.config.layout.showPostCover}">
             <a th:attr="title=${post.spec.title}" th:href="@{${post.status.permalink}}">
                 <img class="post_bg"
+                     th:if="${theme.config.layout.showPostCover}"
                      th:with='img = ${#strings.isEmpty(post.spec.cover) ? postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, "m")}'
                      th:alt="${post.spec.title}"
                      th:data-lazy-src="${ isLazyload ? img : ''}"

--- a/templates/modules/post/relatedPosts.html
+++ b/templates/modules/post/relatedPosts.html
@@ -14,12 +14,14 @@ postRandomImg=${#strings.contains(theme.config.layout.postRandomImg,'?') ? theme
             <!-- 建议阅读，这里可以自定义文章数量，然后遍历展示 -->
             <th:block th:each="recommandPost,iterStat :${recommandPosts}"
                       th:if="${not #strings.equals(post.spec.title, recommandPost.spec.title)}">
-                <div th:if="${!containsTitle ? iterStat.index <6 : true}">
+                <div th:if="${!containsTitle ? iterStat.index <6 : true}" th:classappend="!${theme.config.layout.showPostCover} ? 'related-post-item--no-cover' : ''">
                     <a th:href="@{${recommandPost.status.permalink}}" th:title="${recommandPost.spec.title}">
-                        <img alt="cover" class="cover" id="preimg"
-                             th:with="img = ${#strings.isEmpty(recommandPost.spec.cover) ? postRandomImg+recommandPost.spec.title : thumbnail.gen(recommandPost.spec.cover, 'm')}"
-                             th:src="${isLazyload ? loadingImg : img}"
-                             th:data-lazy-src="${ isLazyload ? img : ''}">
+                        <th:block th:if="${theme.config.layout.showPostCover}">
+                            <img alt="cover" class="cover preimg"
+                                 th:with="img = ${#strings.isEmpty(recommandPost.spec.cover) ? postRandomImg+recommandPost.spec.title : thumbnail.gen(recommandPost.spec.cover, 'm')}"
+                                 th:src="${isLazyload ? loadingImg : img}"
+                                 th:data-lazy-src="${ isLazyload ? img : ''}">
+                        </th:block>
                         <div class="content is-center">
                             <div class="date" style="color: white"><i class="far fa-calendar-alt fa-fw"></i>
                                 [[${#dates.format(recommandPost.spec.publishTime,'yyyy-MM-dd')}]]
@@ -34,13 +36,14 @@ postRandomImg=${#strings.contains(theme.config.layout.postRandomImg,'?') ? theme
         <div th:if="${#strings.equals(recommendQuantity, 'two')}" class="relatedPosts-list">
             <th:block th:each="recommandPost,iterStat :${recommandPosts}"
                       th:if="${not #strings.equals(post.spec.title, recommandPost.spec.title)}">
-                <div th:if="${!containsTitle ? iterStat.index <2 : true}">
+                <div th:if="${!containsTitle ? iterStat.index <2 : true}" th:classappend="!${theme.config.layout.showPostCover} ? 'related-post-item--no-cover' : ''">
                     <a th:href="@{${recommandPost.status.permalink}}" th:title="${recommandPost.spec.title}">
-                        <img class="cover" alt="cover"
-                             th:with="img = ${#strings.isEmpty(recommandPost.spec.cover) ? postRandomImg+recommandPost.spec.title : thumbnail.gen(recommandPost.spec.cover, 'm')}"
-
-                             th:src="${isLazyload ? loadingImg : img}"
-                             th:data-lazy-src="${ isLazyload ? img : ''}">
+                        <th:block th:if="${theme.config.layout.showPostCover}">
+                            <img class="cover" alt="cover"
+                                 th:with="img = ${#strings.isEmpty(recommandPost.spec.cover) ? postRandomImg+recommandPost.spec.title : thumbnail.gen(recommandPost.spec.cover, 'm')}"
+                                 th:src="${isLazyload ? loadingImg : img}"
+                                 th:data-lazy-src="${ isLazyload ? img : ''}">
+                        </th:block>
                         <div class="content is-center">
                             <div class="date"><i class="far fa-calendar-alt fa-fw"></i>
                                 [[${#dates.format(recommandPost.spec.publishTime,'yyyy-MM-dd')}]]</div>

--- a/templates/modules/widgets/aside/recent-posts.html
+++ b/templates/modules/widgets/aside/recent-posts.html
@@ -3,14 +3,16 @@
     <div class="item-headline"><i class="haofont hao-icon-eicon_map-2-line1"></i><span>最近发布</span></div>
     <div class="aside-list">
         <!-- 最新文章，用户可以自定义展示数量 -->
-        <div class="aside-list-item" th:each="post : ${postFinder.list({page: 1, size: theme.config.sidebar.recentPost, sort: {'spec.publishTime,desc'}})}">
-            <a class="thumbnail" th:href="@{${post.status.permalink}}" th:title="${post.spec.title}">
-                <img th:alt="${post.spec.title}"
-                     th:with="img = ${#strings.isEmpty(post.spec.cover) ? postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, 's')}"
-
-                     th:src="${isLazyload ? loadingImg : img}"
-                     th:data-lazy-src="${ isLazyload ? img : ''}">
-            </a>
+        <div class="aside-list-item" th:each="post : ${postFinder.list({page: 1, size: theme.config.sidebar.recentPost, sort: {'spec.publishTime,desc'}})}"
+             th:classappend="!${theme.config.layout.showPostCover} ? 'recent-posts-item--no-cover' : ''">
+            <th:block th:if="${theme.config.layout.showPostCover}">
+                <a class="thumbnail" th:href="@{${post.status.permalink}}" th:title="${post.spec.title}">
+                    <img th:alt="${post.spec.title}"
+                         th:with="img = ${#strings.isEmpty(post.spec.cover) ? postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, 's')}"
+                         th:src="${isLazyload ? loadingImg : img}"
+                         th:data-lazy-src="${ isLazyload ? img : ''}">
+                </a>
+            </th:block>
             <div class="content">
                 <a class="title" th:href="@{${post.status.permalink}}" th:text="${post.spec.title}" th:title="${post.spec.title}"></a>
                 <time th:attr="datetime=${#dates.format(post.spec.publishTime, 'yyyy-MM-dd HH:mm:ss')}"

--- a/templates/modules/widgets/aside/visit-posts.html
+++ b/templates/modules/widgets/aside/visit-posts.html
@@ -1,16 +1,17 @@
-<div class="card-widget card-recent-post" th:with='
-    postRandomImg=${#strings.contains(theme.config.layout.postRandomImg,"?") ? theme.config.layout.postRandomImg+"&" : theme.config.layout.postRandomImg+"?"}'>
+<div class="card-widget card-recent-post">
     <div class="item-headline"><i class="haofont hao-icon-eicon_map-2-line1"></i><span>热门文章</span></div>
     <div class="aside-list">
         <!-- 热门文章，用户可以自定义展示数量 -->
-        <div class="aside-list-item" th:each="post : ${postFinder.list({page: 1, size: theme.config.sidebar.recentPost, sort: {'stats.visit,desc'}})}">
-            <a class="thumbnail" th:href="@{${post.status.permalink}}" th:title="${post.spec.title}">
-                <img th:alt="${post.spec.title}"
-                     th:with="img = ${#strings.isEmpty(post.spec.cover) ? postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, 's')}"
-
-                     th:src="${isLazyload ? loadingImg : img}"
-                     th:data-lazy-src="${ isLazyload ? img : ''}">
-            </a>
+        <div class="aside-list-item" th:each="post : ${postFinder.list({page: 1, size: theme.config.sidebar.recentPost, sort: {'stats.visit,desc'}})}"
+             th:classappend="!${theme.config.layout.showPostCover} ? 'recent-posts-item--no-cover' : ''">
+            <th:block th:if="${theme.config.layout.showPostCover}">
+                <a class="thumbnail" th:href="@{${post.status.permalink}}" th:title="${post.spec.title}">
+                    <img th:alt="${post.spec.title}"
+                         th:with="img = ${#strings.isEmpty(post.spec.cover) ? theme.config.layout.postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, 's')}"
+                         th:src="${isLazyload ? loadingImg : img}"
+                         th:data-lazy-src="${ isLazyload ? img : ''}">
+                </a>
+            </th:block>
             <div class="content">
                 <a class="title" th:href="@{${post.status.permalink}}" th:text="${post.spec.title}" th:title="${post.spec.title}"></a>
                 <time th:attr="datetime=${#dates.format(post.spec.publishTime, 'yyyy-MM-dd HH:mm:ss')}"

--- a/templates/modules/widgets/recent-posts.html
+++ b/templates/modules/widgets/recent-posts.html
@@ -1,0 +1,14 @@
+<div class="aside-list-item"
+     th:each="post : ${postFinder.list({page: 1, size: theme.config.sidebar.recentPost, sort: {'stats.createTime,desc'}})}"
+     th:classappend="!${theme.config.layout.showPostCover} ? 'recent-posts-item--no-cover' : ''">
+    <th:block th:if="${theme.config.layout.showPostCover}">
+        <a class="thumbnail" th:href="@{${post.status.permalink}}" th:title="${post.spec.title}">
+            <img class="post_cover_img"
+                 th:src="${#strings.isEmpty(post.spec.cover) ? theme.config.layout.postRandomImg + post.spec.title : thumbnail.gen(post.spec.cover, 's')}"
+                 th:alt="${post.spec.title}">
+        </a>
+    </th:block>
+    <div class="content">
+        <a class="title" th:href="@{${post.status.permalink}}" th:text="${post.spec.title}" th:title="${post.spec.title}"></a>
+    </div>
+</div> 

--- a/templates/modules/widgets/top-group.html
+++ b/templates/modules/widgets/top-group.html
@@ -4,18 +4,23 @@
     postRandomImg=${#strings.contains(theme.config.layout.postRandomImg,"?") ? theme.config.layout.postRandomImg+"&" : theme.config.layout.postRandomImg+"?"}'>
     <div class="recent-post-group">
         <div class="recent-post-item" th:each="post,iter : ${topGroupPosts}"
-             th:if="${#strings.equals(theme.config.top.BannerRight.recommendPost, 'latest')}">
+             th:if="${#strings.equals(theme.config.top.BannerRight.recommendPost, 'latest')}"
+             th:classappend="!${theme.config.layout.showPostCover} ? 'recent-post-item--no-cover' : ''">
 
-            <div class="post_cover" th:classappend="${iter.index % 2 == 0 ? 'left_radius' : 'right_radius'}">
-                <a th:href="@{${post.status.permalink}}" th:title="${post.spec.title}">
-                    <span class="recent-post-top-text"
-                          th:attr="onclick='pjax.loadUrl(\''+ @{${post.status.permalink}} +'\')'">荐</span>
-                    <img class="post_bg"
-                         th:with=' img = ${#strings.isEmpty(post.spec.cover) ? postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, "s")}'
-                         th:alt="${post.spec.title}" th:src="${isLazyload ? loadingImg : img}"
-                         th:data-lazy-src="${ isLazyload ? img : ''}" />
-                </a>
-            </div>
+            <th:block th:if="${theme.config.layout.showPostCover}">
+                <div class="post_cover" th:classappend="${iter.index % 2 == 0 ? 'left_radius' : 'right_radius'}">
+                    <a th:href="@{${post.status.permalink}}" th:title="${post.spec.title}">
+                        <span class="recent-post-top-text"
+                              th:attr="onclick='pjax.loadUrl(\''+ @{${post.status.permalink}} +'\')'">荐</span>
+                        <img class="post_bg"
+                             th:with=' img = ${#strings.isEmpty(post.spec.cover) ? theme.config.layout.postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, "s")}'
+                             th:alt="${post.spec.title}" th:src="${isLazyload ? loadingImg : img}"
+                             th:data-lazy-src="${ isLazyload ? img : ''}"
+                             th:onclick="logCoverRequest('topGroup-recent', [[${post.spec.title}]], [[${theme.config.layout.postRandomImg+post.spec.title}]])"
+                             >
+                    </a>
+                </div>
+            </th:block>
             <div class="recent-post-info">
                 <a class="article-title" th:href="@{${post.status.permalink}}" th:text="${post.spec.title}"
                    th:title="${post.spec.title}">
@@ -33,7 +38,9 @@
                         <img class="post_bg"
                              th:with='img = ${#strings.isEmpty(post.spec.cover) ? postRandomImg+post.spec.title : thumbnail.gen(post.spec.cover, "s")}'
                              th:alt="${post.spec.title}" th:src="${isLazyload ? loadingImg : img}"
-                             th:data-lazy-src="${ isLazyload ? img : ''}" />
+                             th:data-lazy-src="${ isLazyload ? img : ''}"
+                             th:onclick="logCoverRequest('topGroup-custom', [[${post.spec.title}]], [[${postRandomImg+post.spec.title}]])"
+                             th:if="${theme.config.layout.showPostCover}" />
                     </a>
                 </div>
                 <div class="recent-post-info">

--- a/templates/post.html
+++ b/templates/post.html
@@ -14,8 +14,10 @@
         <header class="post-bg" id="page-header">
             <nav th:replace="~{modules/nav :: nav(title = ${post.spec.title})}"></nav>
             <div class="coverdiv loaded" id="coverdiv">
-                <img alt="cover" class="nolazyload" id="post-cover"
-                     th:src="${#strings.isEmpty(post.spec.cover) ? theme.config.layout.postRandomImg : post.spec.cover}">
+                <img class="post_cover_img"
+                     th:if="${theme.config.layout.showPostCover}"
+                     th:src="${#strings.isEmpty(post.spec.cover) ? theme.config.layout.postRandomImg : post.spec.cover}"
+                     th:alt="${post.spec.title}">
             </div>
 
             <div id="post-info">
@@ -200,11 +202,12 @@
                      postRandomImg=${#strings.contains(theme.config.layout.postRandomImg,'?') ? theme.config.layout.postRandomImg+'&' : theme.config.layout.postRandomImg+'?'}">
                     <div th:if="${postCursor.hasPrevious()}" th:class="${postCursor.hasNext()==false} ? 'prev-post pull-full ' : 'prev-post pull-left'">
                         <a th:if="${postCursor.hasPrevious()}" th:href="@{${postCursor.previous.status.permalink}}">
-                            <img alt="cover" id="preimg" class="nolazyload"
-                                 th:with="img = ${#strings.isEmpty(postCursor.previous.spec.cover) ? postRandomImg+postCursor.previous.spec.title : thumbnail.gen(postCursor.previous.spec.cover, 'm')}"
-                                 th:src="${isLazyload ? loadingImg : img}"
-
-                                 th:data-lazy-src="${ isLazyload ? img : ''}">
+                            <th:block th:if="${theme.config.layout.showPostCover}">
+                                <img alt="cover" id="prevPostImg" class="nolazyload"
+                                     th:with="img = ${#strings.isEmpty(postCursor.previous.spec.cover) ? postRandomImg+postCursor.previous.spec.title : thumbnail.gen(postCursor.previous.spec.cover, 'm')}"
+                                     th:src="${isLazyload ? loadingImg : img}"
+                                     th:data-lazy-src="${ isLazyload ? img : ''}">
+                            </th:block>
                             <div class="pagination-info">
                                 <div class="label">上一篇</div>
                                 <div class="prev_info" th:text="${postCursor.previous.spec.title}"></div>
@@ -213,10 +216,12 @@
                     </div>
                     <div th:if="${postCursor.hasNext()}" th:class="${postCursor.hasPrevious()==false} ? 'next-post pull-full ':'next-post pull-right'">
                         <a th:if="${postCursor.hasNext()}" th:href="@{${postCursor.next.status.permalink}}">
-                            <img alt="cover" id="preimg" class="nolazyload"
-                                 th:with="img = ${#strings.isEmpty(postCursor.next.spec.cover) ? postRandomImg+postCursor.next.spec.title : thumbnail.gen(postCursor.next.spec.cover, 'm')}"
-                                 th:src="${isLazyload ? loadingImg : img}"
-                                 th:data-lazy-src="${ isLazyload ? img : ''}">
+                            <th:block th:if="${theme.config.layout.showPostCover}">
+                                <img alt="cover" id="nextPostImg" class="nolazyload"
+                                     th:with="img = ${#strings.isEmpty(postCursor.next.spec.cover) ? postRandomImg+postCursor.next.spec.title : thumbnail.gen(postCursor.next.spec.cover, 'm')}"
+                                     th:src="${isLazyload ? loadingImg : img}"
+                                     th:data-lazy-src="${ isLazyload ? img : ''}">
+                            </th:block>
                             <div class="pagination-info">
                                 <div class="label">下一篇</div>
                                 <div class="next_info" th:text="${postCursor.next.spec.title}"></div>


### PR DESCRIPTION
- 在 settings.yaml 中添加 showPostCover 选项，用于控制文章封面图的显示
- 更新多个 HTML 文件以支持新的封面图显示设置